### PR TITLE
Dual firewall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
 gem "librarian-puppet", "2.0.0"
-gem "puppet",           "3.7.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
     activemodel (4.1.7)
       activesupport (= 4.1.7)
       builder (~> 3.1)
@@ -12,8 +11,6 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     builder (3.2.2)
-    facter (2.3.0)
-      CFPropertyList (~> 2.2.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     her (0.7.2)
@@ -21,12 +18,9 @@ GEM
       activesupport (>= 3.0.0, < 4.2)
       faraday (>= 0.8, < 1.0)
       multi_json (~> 1.7)
-    hiera (1.3.4)
-      json_pure
     highline (1.6.21)
     i18n (0.6.11)
     json (1.8.1)
-    json_pure (1.8.1)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -37,10 +31,6 @@ GEM
     minitest (5.4.3)
     multi_json (1.10.1)
     multipart-post (2.0.0)
-    puppet (3.7.3)
-      facter (> 1.6, < 3)
-      hiera (~> 1.0)
-      json_pure
     puppet_forge (1.0.3)
       her (~> 0.6)
     rsync (1.0.9)
@@ -54,4 +44,6 @@ PLATFORMS
 
 DEPENDENCIES
   librarian-puppet (= 2.0.0)
-  puppet (= 3.7.3)
+
+BUNDLED WITH
+   1.10.6

--- a/manifests/zig-or-att.pp
+++ b/manifests/zig-or-att.pp
@@ -1,0 +1,5 @@
+node /^zig-or-att/ {
+  include spraints::basenode
+
+  include spraints::role::router
+}

--- a/modules/spraints/manifests/basenode.pp
+++ b/modules/spraints/manifests/basenode.pp
@@ -7,7 +7,6 @@ class spraints::basenode($location = "home") {
     ensure => present,
     mode => 644,
     owner => root,
-    group => root,
     content => template("spraints/etc/hosts.erb"),
   }
 }

--- a/modules/spraints/manifests/device/interface.pp
+++ b/modules/spraints/manifests/device/interface.pp
@@ -1,18 +1,24 @@
 define spraints::device::interface(
   $interface = $name,
-  $mode      = undef
+  $dhcp      = false,
+  $address   = undef,
+  $netmask   = undef,
+  $bcast     = undef,
 ) {
   if $::operatingsystem == "OpenBSD" {
-    if $mode == undef {
+    if $dhcp == false and $address == undef {
+
       file { "/etc/hostname.${interface}":
         ensure  => absent,
       }
+
     } else {
+
       file { "/etc/hostname.${interface}":
         ensure  => present,
         owner   => "root",
         mode    => "444",
-        content => $mode,
+        content => template("spraints/etc/hostname.if.erb"),
         notify  => Exec["restart ${interface}"],
       }
 

--- a/modules/spraints/manifests/device/interface.pp
+++ b/modules/spraints/manifests/device/interface.pp
@@ -26,6 +26,7 @@ define spraints::device::interface(
         command => "sh /etc/netstart ${interface}",
         path    => "/bin:/usr/bin:/sbin:/usr/sbin",
         user    => "root",
+        refreshonly => true,
       }
     }
   }

--- a/modules/spraints/manifests/device/interface.pp
+++ b/modules/spraints/manifests/device/interface.pp
@@ -17,7 +17,7 @@ define spraints::device::interface(
       file { "/etc/hostname.${interface}":
         ensure  => present,
         owner   => "root",
-        mode    => "444",
+        mode    => "440",
         content => template("spraints/etc/hostname.if.erb"),
         notify  => Exec["restart ${interface}"],
       }

--- a/modules/spraints/manifests/device/interface.pp
+++ b/modules/spraints/manifests/device/interface.pp
@@ -1,0 +1,26 @@
+define spraints::device::interface(
+  $interface = $name,
+  $mode      = undef
+) {
+  if $::operatingsystem == "OpenBSD" {
+    if $mode == undef {
+      file { "/etc/hostname.${interface}":
+        ensure  => absent,
+      }
+    } else {
+      file { "/etc/hostname.${interface}":
+        ensure  => present,
+        owner   => "root",
+        mode    => "444",
+        content => $mode,
+        notify  => Exec["restart ${interface}"],
+      }
+
+      exec { "restart ${interface}":
+        command => "sh /etc/netstart ${interface}",
+        path    => "/bin:/usr/bin:/sbin:/usr/sbin",
+        user    => "root",
+      }
+    }
+  }
+}

--- a/modules/spraints/manifests/role/att_wireless.pp
+++ b/modules/spraints/manifests/role/att_wireless.pp
@@ -6,16 +6,16 @@ class spraints::role::att_wireless(
 
   file { "/etc/collectd/collectd.conf.d/att_wireless.conf":
     ensure => present,
-    owner => "root",
-    group => "root",
+    mode   => 644,
+    owner  => "root",
     source => "puppet:///modules/spraints/etc/collectd/collectd.conf.d/att_wireless.conf",
     notify => Service["collectd"],
   }
 
   file { "/opt/collectd/att_wireless":
     ensure => present,
-    owner => "root",
-    group => "root",
+    owner  => "root",
+    mode   => 644,
     source => "puppet:///modules/spraints/opt/collectd/att_wireless",
     mode => "0555",
     require => [
@@ -27,8 +27,8 @@ class spraints::role::att_wireless(
 
   file { "/opt/collectd":
     ensure => directory,
-    owner => "root",
-    group => "root",
+    owner  => "root",
+    mode   => 644,
   }
 
   package { "jq":

--- a/modules/spraints/manifests/role/att_wireless.pp
+++ b/modules/spraints/manifests/role/att_wireless.pp
@@ -15,9 +15,8 @@ class spraints::role::att_wireless(
   file { "/opt/collectd/att_wireless":
     ensure => present,
     owner  => "root",
-    mode   => 644,
     source => "puppet:///modules/spraints/opt/collectd/att_wireless",
-    mode => "0555",
+    mode   => "555",
     require => [
       File["/opt/collectd"],
       Package["jq"],

--- a/modules/spraints/manifests/role/network_monitor.pp
+++ b/modules/spraints/manifests/role/network_monitor.pp
@@ -10,7 +10,6 @@ class spraints::role::network_monitor(
     notify  => Service["collectd"],
     mode    => 644,
     owner   => "root",
-    group   => "root",
     source  => "puppet:///modules/spraints/etc/default/collectd",
   }
 
@@ -19,7 +18,6 @@ class spraints::role::network_monitor(
       notify  => Service["collectd"],
       mode    => 644,
       owner   => "root",
-      group   => "root",
       source  => "puppet:///modules/spraints/etc/collectd/collectd.conf.d/airport-snmp.conf",
       require => [
         Package["snmp-mibs-downloader"],
@@ -32,7 +30,6 @@ class spraints::role::network_monitor(
     notify  => Service["collectd"],
     mode    => 644,
     owner   => "root",
-    group   => "root",
     content => template("spraints/etc/collectd/collectd.conf.d/ping-the-world.conf.erb"),
   }
 
@@ -44,7 +41,6 @@ class spraints::role::network_monitor(
     file { "/usr/share/snmp/mibs/AIRPORT-BASESTATION-3-MIB.txt":
       mode    => 644,
       owner   => "root",
-      group   => "root",
       source  => "puppet:///modules/spraints/usr/share/snmp/mibs/AIRPORT-BASESTATION-3-MIB.txt",
     }
   }

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -2,9 +2,10 @@
 # are routed to AT&T always. Some hosts can self-select
 # AT&T for all of their traffic for a limited time.
 class spraints::role::router(
-  $zig_if = "en1",
-  $att_if = "en2",
-  $inf_if = "en3",
+  $zig_if = "re0",
+  $att_if = "re1",
+  $inf_if = "re2",
+  $mgm_if = "re3"
   $int_ip = "192.168.100.2",
   $int_net = "192.168.100",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
@@ -20,12 +21,14 @@ class spraints::role::router(
     "hostname.${zig_if}" => "dhcp",
     "hostname.${att_if}" => "dhcp",
     "hostname.${int_if}" => "inet $int_ip 255.255.255.0 $int_net.255",
+    "hostname.${mgm_if}" => "dhcp",
   }
 
   file { [
            "/etc/hostname.${zig_if}",
            "/etc/hostname.${att_if}",
            "/etc/hostname.${int_if}",
+           "/etc/hostname.${mgm_if}",
          ]:
     ensure  => present,
     owner   => "root",
@@ -36,7 +39,7 @@ class spraints::role::router(
   }
 
   exec { "restart networking":
-    command => "sh /etc/netstart ${zig_if} && sh /etc/netstart ${att_if} && sh /etc/netstart ${int_if}",
+    command => "sh /etc/netstart ${zig_if} && sh /etc/netstart ${att_if} && sh /etc/netstart ${int_if} && sh /etc/netstart ${mgm_if}",
     path    => $exec_path,
     user    => "root",
     group   => "root",

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -3,22 +3,19 @@
 # AT&T for all of their traffic for a limited time.
 class spraints::role::router(
   $zig_if = "en1",
-  $zig_ip = "192.168.3.1",
-  $local_zig_ip = "192.168.3.2",
   $att_if = "en2",
-  $att_ip = "192.168.0.1",
-  $local_att_ip = "192.168.0.2",
   $inf_if = "en3",
   $int_ip = "192.168.100.2",
+  $int_bcast = "192.168.100.255",
 ) {
   include spraints::app::zig-or-att
 
   # IP addresses
 
   $hostname_ifs = {
-    "hostname.${zig_if}" => "inet $local_zig_ip 255.255.255.0 $zig_bcast",
-    "hostname.${att_if}" => "inet $local_att_ip 255.255.255.0 $att_bcast",
-    "hostname.${int_if}" => "inet $int_ip       255.255.255.0 $int_bcast",
+    "hostname.${zig_if}" => "dhcp",
+    "hostname.${att_if}" => "dhcp",
+    "hostname.${int_if}" => "inet $int_ip 255.255.255.0 $int_bcast",
   }
 
   file { [

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -1,0 +1,38 @@
+# Routes traffic to zig wireless by default. Some apps
+# are routed to AT&T always. Some hosts can self-select
+# AT&T for all of their traffic for a limited time.
+class spraints::role::router(
+  $zig_if = "en1",
+  $zig_ip = "192.168.3.1",
+  $local_zig_ip = "192.168.3.2",
+  $att_if = "en2",
+  $att_ip = "192.168.0.1",
+  $local_att_ip = "192.168.0.2",
+  $inf_if = "en3",
+  $int_ip = "192.168.100.2",
+) {
+  include spraints::app::zig-or-att
+
+  # Firewall
+
+  file { "/etc/pf.conf":
+    ensure => present,
+    owner  => "root",
+    group  => "root",
+    mode   => "444",
+    source => template("spraints/etc/pf.conf.erb"),
+    notify => Exec["reload pf.conf"],
+  }
+
+  exec { "reload pf.conf":
+    command => "pfctl -e -f /etc/pf.conf",
+    path    => "/sbin",
+    user    => "root",
+    group   => "root",
+  }
+
+  # DNS mirror
+  # todo
+
+  # DHCP server
+}

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -17,10 +17,12 @@ class spraints::role::router(
 
   # IP addresses
 
-  spraints::device::interface { $zig_if: mode => "dhcp" }
-  spraints::device::interface { $att_if: mode => "dhcp" }
-  spraints::device::interface { $int_if: mode => "inet $int_ip 255.255.255.0 $int_net.255" }
-  spraints::device::interface { $mgm_if: mode => "dhcp" }
+  spraints::device::interface { [$zig_if, $att_if, $mgm_if]:
+    dhcp => true,
+  }
+  spraints::device::interface { $int_if:
+    address => $int_ip,
+  }
 
   ###
   # Firewall

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -16,6 +16,10 @@ class spraints::role::router(
 
   # IP addresses
 
+  # DHCP on these is nice, because there's less to configure manually.
+  # But DHCP on these bites because I can't choose a default route with /etc/mygate
+  # and pf will barf if the NIC isn't connected, because the interface won't have an IP
+  # address.
   spraints::device::interface { [$zig_if, $att_if, $mgm_if]:
     dhcp => true,
   }

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -32,7 +32,6 @@ class spraints::role::router(
          ]:
     ensure  => present,
     owner   => "root",
-    group   => "root",
     mode    => "444",
     content => $hostname_ifs[$name],
     notify  => Exec["restart networking"],
@@ -42,7 +41,6 @@ class spraints::role::router(
     command => "sh /etc/netstart ${zig_if} && sh /etc/netstart ${att_if} && sh /etc/netstart ${int_if} && sh /etc/netstart ${mgm_if}",
     path    => $exec_path,
     user    => "root",
-    group   => "root",
   }
 
   # Firewall
@@ -50,7 +48,6 @@ class spraints::role::router(
   file { "/etc/pf.conf":
     ensure  => present,
     owner   => "root",
-    group   => "root",
     mode    => "444",
     content => template("spraints/etc/pf.conf.erb"),
     notify  => Exec["reload pf.conf"],
@@ -60,7 +57,6 @@ class spraints::role::router(
     command => "pfctl -e -f /etc/pf.conf",
     path    => $exec_path,
     user    => "root",
-    group   => "root",
   }
 
   # DNS mirror
@@ -69,13 +65,11 @@ class spraints::role::router(
     command => "rcctl enable unbound && rcctl stop unbound && rcctl start unbound",
     path    => $exec_path,
     user    => "root",
-    group   => "root",
   }
 
   file { "/var/unbound/etc/unbound.conf":
     ensure  => present,
     owner   => "root",
-    group   => "root",
     mode    => "444",
     content => template("spraints/var/unbound/etc/unbound.conf.erb"),
     notify  => Exec["start unbound"],
@@ -87,13 +81,11 @@ class spraints::role::router(
     command => "rcctl enable dhcpd && rcctl set dhcpd flags $int_if && rcctl stop dhcpd && rcctl start dhcpd",
     path    => $exec_path,
     user    => "root",
-    group   => "root",
   }
 
   file { "/etc/dhcpd.conf":
     ensure  => present,
     owner   => "root",
-    group   => "root",
     mode    => "444",
     content => template("spraints/etc/dhcpd.conf.erb"),
     notify  => Exec["start dhcpd $int_if"],

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -46,6 +46,7 @@ class spraints::role::router(
     command => "pfctl -e -f /etc/pf.conf",
     path    => $exec_path,
     user    => "root",
+    refreshonly => true,
   }
 
   file { "/etc/sysctl.conf":
@@ -60,6 +61,7 @@ class spraints::role::router(
     command => "sysctl net.inet.ip.forwarding=1",
     path    => $exec_path,
     user    => "root",
+    onlyif  => "sysctl | grep net.inet.ip.forwarding=0",
   }
 
   ###
@@ -74,6 +76,7 @@ class spraints::role::router(
     path    => $exec_path,
     user    => "root",
     require => Package["unbound"],
+    refreshonly => true,
   }
 
   file { "/var/unbound/etc/unbound.conf":
@@ -93,6 +96,7 @@ class spraints::role::router(
     command => "rcctl enable dhcpd && rcctl set dhcpd flags $int_if && rcctl stop dhcpd && rcctl start dhcpd",
     path    => $exec_path,
     user    => "root",
+    refreshonly => true,
   }
 
   file { "/etc/dhcpd.conf":

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -43,7 +43,7 @@ class spraints::role::router(
   }
 
   exec { "reload pf.conf":
-    command => "pfctl -e -f /etc/pf.conf",
+    command => "pfctl -f /etc/pf.conf",
     path    => $exec_path,
     user    => "root",
     refreshonly => true,

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -4,7 +4,7 @@
 class spraints::role::router(
   $zig_if = "re0",
   $att_if = "re1",
-  $inf_if = "re2",
+  $int_if = "re2",
   $mgm_if = "re3",
   $int_ip = "192.168.100.2",
   $int_net = "192.168.100",
@@ -17,31 +17,10 @@ class spraints::role::router(
 
   # IP addresses
 
-  $hostname_ifs = {
-    "hostname.${zig_if}" => "dhcp",
-    "hostname.${att_if}" => "dhcp",
-    "hostname.${int_if}" => "inet $int_ip 255.255.255.0 $int_net.255",
-    "hostname.${mgm_if}" => "dhcp",
-  }
-
-  file { [
-           "/etc/hostname.${zig_if}",
-           "/etc/hostname.${att_if}",
-           "/etc/hostname.${int_if}",
-           "/etc/hostname.${mgm_if}",
-         ]:
-    ensure  => present,
-    owner   => "root",
-    mode    => "444",
-    content => $hostname_ifs[$name],
-    notify  => Exec["restart networking"],
-  }
-
-  exec { "restart networking":
-    command => "sh /etc/netstart ${zig_if} && sh /etc/netstart ${att_if} && sh /etc/netstart ${int_if} && sh /etc/netstart ${mgm_if}",
-    path    => $exec_path,
-    user    => "root",
-  }
+  spraints::device::interface { $zig_if: mode => "dhcp" }
+  spraints::device::interface { $att_if: mode => "dhcp" }
+  spraints::device::interface { $int_if: mode => "inet $int_ip 255.255.255.0 $int_net.255" }
+  spraints::device::interface { $mgm_if: mode => "dhcp" }
 
   # Firewall
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -11,7 +11,7 @@ class spraints::role::router(
   $int_net = "192.168.100",
   $mgm_if = "re3",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
-  $dhcp_name_servers = [ "8.8.8.8", $int_ip, "192.168.100.81" ],
+  $dhcp_name_servers = [ "8.8.8.8", "192.168.100.2", "192.168.100.81" ],
 ) {
   #include spraints::app::zig-or-att
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -8,6 +8,7 @@ class spraints::role::router(
   $int_ip = "192.168.100.2",
   $int_net = "192.168.100",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
+  $turbo_sites = [ "10.10.10.0/31" ],
 ) {
   include spraints::app::zig-or-att
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -3,11 +3,13 @@
 # AT&T for all of their traffic for a limited time.
 class spraints::role::router(
   $zig_if = "re0",
+  $zig_gw = "192.168.3.1",
   $att_if = "re1",
+  $att_gw = "192.168.0.1",
   $int_if = "re2",
-  $mgm_if = "re3",
   $int_ip = "192.168.100.2",
   $int_net = "192.168.100",
+  $mgm_if = "re3",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
 ) {
   #include spraints::app::zig-or-att
@@ -43,7 +45,7 @@ class spraints::role::router(
   }
 
   exec { "reload pf.conf":
-    command => "pfctl -f /etc/pf.conf",
+    command => "pfctl -n -f /etc/pf.conf && pfctl -f /etc/pf.conf",
     path    => $exec_path,
     user    => "root",
     refreshonly => true,

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -11,7 +11,7 @@ class spraints::role::router(
   $int_net = "192.168.100",
   $mgm_if = "re3",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
-  $dhcp_name_servers = [ "8.8.8.8", "192.168.100.2", "192.168.100.81" ],
+  $dhcp_name_servers = [ "192.168.100.2", "192.168.100.81" ],
 ) {
   #include spraints::app::zig-or-att
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -60,12 +60,27 @@ class spraints::role::router(
   }
 
   # DNS mirror
-  # todo
+
+  exec { "start unbound":
+    command => "rcctl enable unbound && rcctl stop unbound && rcctl start unbound",
+    path    => $exec_path,
+    user    => "root",
+    group   => "root",
+  }
+
+  file { "/var/unbound/etc/unbound.conf":
+    ensure  => present,
+    owner   => "root",
+    group   => "root",
+    mode    => "444",
+    content => template("spraints/var/unbound/etc/unbound.conf.erb"),
+    notify  => Exec["start unbound"],
+  }
 
   # DHCP server
 
-  exec { "enable dhcp $int_if":
-    command => "rcctl enable dhcpd && rcctl set dhcpd flags $int_if",
+  exec { "start dhcpd $int_if":
+    command => "rcctl enable dhcpd && rcctl set dhcpd flags $int_if && rcctl stop dhcpd && rcctl start dhcpd",
     path    => $exec_path,
     user    => "root",
     group   => "root",
@@ -77,5 +92,6 @@ class spraints::role::router(
     group   => "root",
     mode    => "444",
     content => template("spraints/etc/dhcpd.conf.erb"),
+    notify  => Exec["start dhcpd $int_if"],
   }
 }

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -42,6 +42,20 @@ class spraints::role::router(
     user    => "root",
   }
 
+  file { "/etc/sysctl.conf":
+    ensure  => present,
+    owner   => "root",
+    mode    => "444",
+    content => "net.inet.ip.forwarding=1\n",
+    notify  => Exec["enable ip forwarding"],
+  }
+
+  exec { "enable ip forwarding":
+    command => "sysctl net.inet.ip.forwarding=1",
+    path    => $exec_path,
+    user    => "root",
+  }
+
   ###
   # DNS mirror
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -21,10 +21,12 @@ class spraints::role::router(
   # and pf will barf if the NIC isn't connected, because the interface won't have an IP
   # address.
   spraints::device::interface { [$zig_if, $att_if, $mgm_if]:
-    dhcp => true,
+    dhcp    => true,
+    notify  => Exec["reload pf.conf"],
   }
   spraints::device::interface { $int_if:
     address => $int_ip,
+    notify  => Exec["reload pf.conf"],
   }
 
   ###

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -11,6 +11,7 @@ class spraints::role::router(
   $int_net = "192.168.100",
   $mgm_if = "re3",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
+  $dhcp_name_servers = [ "8.8.8.8", $int_ip, "192.168.100.81" ],
 ) {
   #include spraints::app::zig-or-att
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -11,7 +11,7 @@ class spraints::role::router(
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
   $turbo_sites = [ "10.10.10.0/31" ],
 ) {
-  include spraints::app::zig-or-att
+  #include spraints::app::zig-or-att
 
   $exec_path = "/bin:/usr/bin:/sbin:/usr/sbin"
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -9,7 +9,6 @@ class spraints::role::router(
   $int_ip = "192.168.100.2",
   $int_net = "192.168.100",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },
-  $turbo_sites = [ "10.10.10.0/31" ],
 ) {
   #include spraints::app::zig-or-att
 

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -22,7 +22,10 @@ class spraints::role::router(
   spraints::device::interface { $int_if: mode => "inet $int_ip 255.255.255.0 $int_net.255" }
   spraints::device::interface { $mgm_if: mode => "dhcp" }
 
+  ###
   # Firewall
+
+  # pf is included in the base OS on OpenBSD.
 
   file { "/etc/pf.conf":
     ensure  => present,
@@ -38,6 +41,7 @@ class spraints::role::router(
     user    => "root",
   }
 
+  ###
   # DNS mirror
 
   package { "unbound":
@@ -59,7 +63,10 @@ class spraints::role::router(
     notify  => Exec["start unbound"],
   }
 
+  ###
   # DHCP server
+
+  # dhcpd is included in the base OS on OpenBSD.
 
   exec { "start dhcpd $int_if":
     command => "rcctl enable dhcpd && rcctl set dhcpd flags $int_if && rcctl stop dhcpd && rcctl start dhcpd",

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -40,10 +40,15 @@ class spraints::role::router(
 
   # DNS mirror
 
+  package { "unbound":
+    ensure => installed,
+  }
+
   exec { "start unbound":
     command => "rcctl enable unbound && rcctl stop unbound && rcctl start unbound",
     path    => $exec_path,
     user    => "root",
+    require => Package["unbound"],
   }
 
   file { "/var/unbound/etc/unbound.conf":

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -5,7 +5,7 @@ class spraints::role::router(
   $zig_if = "re0",
   $att_if = "re1",
   $inf_if = "re2",
-  $mgm_if = "re3"
+  $mgm_if = "re3",
   $int_ip = "192.168.100.2",
   $int_net = "192.168.100",
   $dhcp_reservations = { "host" => {"ip" => "192.168.100.49", "mac" => "11:22:33:44:55:66"} },

--- a/modules/spraints/manifests/role/weather_station.pp
+++ b/modules/spraints/manifests/role/weather_station.pp
@@ -5,8 +5,8 @@ class spraints::role::weather_station {
   # fowsr + collectd
   file { "/etc/collectd/collectd.conf.d/fowsr.conf":
     ensure => present,
-    owner => "root",
-    group => "root",
+    owner  => "root",
+    mode   => "444",
     source => "puppet:///modules/spraints/etc/collectd/collectd.conf.d/fowsr.conf",
   }
 
@@ -26,7 +26,7 @@ class spraints::role::weather_station {
   file { "/etc/init/fowsr-wunderground.conf":
     ensure => present,
     source => "puppet:///modules/spraints/etc/init/fowsr-wunderground.conf",
-    owner => "root",
-    group => "root",
+    owner  => "root",
+    mode   => "444",
   }
 }

--- a/modules/spraints/manifests/services/collectd.pp
+++ b/modules/spraints/manifests/services/collectd.pp
@@ -13,7 +13,6 @@ class spraints::services::collectd {
     notify  => Service["collectd"],
     mode    => 644,
     owner   => "root",
-    group   => "root",
     source  => "puppet:///modules/spraints/etc/collectd/collectd.conf",
   }
 
@@ -21,7 +20,6 @@ class spraints::services::collectd {
     notify  => Service["collectd"],
     mode    => 644,
     owner   => "root",
-    group   => "root",
     source  => "puppet:///modules/spraints/etc/collectd/collectd.conf.d/config.conf",
   }
 }

--- a/modules/spraints/manifests/services/fowsr.pp
+++ b/modules/spraints/manifests/services/fowsr.pp
@@ -14,8 +14,8 @@ class spraints::services::fowsr {
   file { "/etc/init/fowsr.conf":
     ensure => present,
     source => "puppet:///modules/spraints/etc/init/fowsr.conf",
-    owner => "root",
-    group => "root",
+    owner  => "root",
+    mode   => "444",
   }
 
   user { "fowsr":

--- a/modules/spraints/manifests/services/ntp.pp
+++ b/modules/spraints/manifests/services/ntp.pp
@@ -1,10 +1,12 @@
 class spraints::services::ntp {
-  package { "ntp":
-    ensure => "present",
-  }
+  if $::operatingsystem != "OpenBSD" {
+    package { "ntp":
+      ensure => "present",
+    }
 
-  service { "ntp":
-    ensure => "running",
-    require => Package["ntp"],
+    service { "ntp":
+      ensure => "running",
+      require => Package["ntp"],
+    }
   }
 }

--- a/modules/spraints/manifests/services/visage.pp
+++ b/modules/spraints/manifests/services/visage.pp
@@ -4,10 +4,10 @@ class spraints::services::visage {
   $visage_config_path = "/var/local/visage"
 
   file { "/etc/init/visage.conf":
-    ensure => present,
+    ensure  => present,
     content => template("spraints/etc/init/visage.conf.erb"),
-    owner => "root",
-    group => "root",
+    owner   => "root",
+    mode    => "444",
     require => File["/opt/visage/config.ru"],
   }
 

--- a/modules/spraints/templates/etc/dhcpd.conf.erb
+++ b/modules/spraints/templates/etc/dhcpd.conf.erb
@@ -1,0 +1,11 @@
+option domain-name-servers <%= @int_ip %>;
+subnet <%= @int_net %>.0 netmask 255.255.255.0 {
+  option routers <%= @int_ip %>;
+  range <%= @int_net %>.100 <%= @int_net %>.199;
+  <% @dhcpd_reservations.each do |name, attrs| %>
+  host <%= name %> {
+    fixed-address <%= attrs["ip"] %>;
+    hardware ethernet <%= attrs["mac"] %>;
+  }
+  <% end %>
+}

--- a/modules/spraints/templates/etc/dhcpd.conf.erb
+++ b/modules/spraints/templates/etc/dhcpd.conf.erb
@@ -1,4 +1,4 @@
-option domain-name-servers <%= @int_ip %>;
+option domain-name-servers <%= @dhcp_name_servers.join(", ") %>;
 subnet <%= @int_net %>.0 netmask 255.255.255.0 {
   option routers <%= @int_ip %>;
   range <%= @int_net %>.100 <%= @int_net %>.199;

--- a/modules/spraints/templates/etc/dhcpd.conf.erb
+++ b/modules/spraints/templates/etc/dhcpd.conf.erb
@@ -2,7 +2,7 @@ option domain-name-servers <%= @int_ip %>;
 subnet <%= @int_net %>.0 netmask 255.255.255.0 {
   option routers <%= @int_ip %>;
   range <%= @int_net %>.100 <%= @int_net %>.199;
-  <% @dhcpd_reservations.each do |name, attrs| %>
+  <% @dhcp_reservations.each do |name, attrs| %>
   host <%= name %> {
     fixed-address <%= attrs["ip"] %>;
     hardware ethernet <%= attrs["mac"] %>;

--- a/modules/spraints/templates/etc/hostname.if.erb
+++ b/modules/spraints/templates/etc/hostname.if.erb
@@ -1,0 +1,3 @@
+<% if @dhcp %>dhcp
+<% else %>inet <%= @address %> <%= @netmask || "255.255.255.0" %> <%= @bcast || @address.to_s.sub(/\.[d+]$/, ".255") %>
+<% end %>

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -2,6 +2,7 @@ zig_if=<%= @zig_if %>
 att_if=<%= @att_if %>
 int_if=<%= @int_if %>
 mgm_if=<%= @mgm_if %>
+int_net=<%= @int_net %>.0/24
 
 ext_ifs="{" $zig_if $att_if "}"
 int_ifs=$int_if

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -2,13 +2,6 @@ zig_if=<%= @zig_if %>
 att_if=<%= @att_if %>
 int_if=<%= @int_if %>
 
-zig_ip=<%= @zig_ip %>
-att_ip=<%= @att_ip %>
-
-local_zig_ip=<%= @local_zig_ip %>
-local_att_ip=<%= @local_att_ip %>
-local_ip=<%= @int_ip %>
-
 ext_ifs="{" $zig_if $att_if "}"
 int_ifs=$int_if
 

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -1,0 +1,10 @@
+zig_if=<%= @zig_if %>
+att_if=<%= @att_if %>
+int_if=<%= @int_if %>
+
+zig_ip=<%= @zig_ip %>
+att_ip=<%= @att_ip %>
+
+local_zig_ip=<%= @local_zig_ip %>
+local_att_ip=<%= @local_att_ip %>
+local_ip=<%= @int_ip %>

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -32,7 +32,7 @@ match out on $att_if proto {udp,tcp} from any to any port $turbo_ports nat-to $a
 pass all
 block in on $ext_ifs
 # Let me ssh from the external networks. This might be useful some day?
-pass in on $ext_ifs from any to any port ssh
+pass in on $ext_ifs proto tcp from any to any port ssh
 # Everything outgoing is OK.
 pass out inet
 pass out on $ext_ifs proto tcp modulate state

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -1,7 +1,8 @@
-zig_if  = "<%= @zig_if %>"
-att_if  = "<%= @att_if %>"
-int_if  = "<%= @int_if %>"
-mgm_if  = "<%= @mgm_if %>"
+zig_if  = <%= @zig_if %>
+att_if  = <%= @att_if %>
+int_if  = <%= @int_if %>
+mgm_if  = <%= @mgm_if %>
+int_net = <%= @int_if %>:network
 
 ext_ifs="{" $zig_if $att_if "}"
 int_ifs=$int_if
@@ -19,16 +20,16 @@ table <turbo_sites> counters
 match in all scrub (no-df random-id max-mss 1440)
 
 # Default all traffic to zig
-match out on $zig_if inet proto tcp modulate state from $int_if:network to any nat-to $zig_if
-match out on $zig_if inet proto udp     keep state from $int_if:network to any nat-to $zig_if
-match out on $zig_if inet                          from $int_if:network to any nat-to $zig_if
+match out on $zig_if inet proto tcp modulate state from $int_net to any nat-to $zig_if
+match out on $zig_if inet proto udp     keep state from $int_net to any nat-to $zig_if
+match out on $zig_if inet                          from $int_net to any nat-to $zig_if
 
 # <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
 match out on $att_if inet from <turbo_hosts> to any nat-to $att_if
 # <turbo_sites> is a list of sites that should always be FAST
-match out on $att_if inet from $int_if:network to <turbo_sites> nat-to $att_if
+match out on $att_if inet from $int_net to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
-match out on $att_if inet proto tcp from $int_if:network to any port 22 nat-to $att_if
+match out on $att_if inet proto tcp from $int_net to any port 22 nat-to $att_if
 
 block all
 pass out quick inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -15,9 +15,20 @@ int_ifs=$int_if
 set block-policy drop
 set skip on lo0
 
+# This table will be manipulated at runtime
+table <turbo_hosts> counters
+
 match in all scrub (no-df random-id max-mss 1440)
-match out on $att_if inet from $int_net to any nat-to $att_if
-match out on $zig_if inet from $int_net to any nat-to $zig_if
+
+# Default all traffic to zig
+match out on $zig_if inet proto tcp modulate state from $int_net to any nat-to $zig_if
+match out on $zig_if inet proto udp     keep state from $int_net to any nat-to $zig_if
+match out on $zig_if inet                          from $int_net to any nat-to $zig_if
+
+# <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
+match out on $att_if inet from <turbo_hosts> to any nat-to $att_if
+# Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
+match out on $att_if inet proto tcp from any to any port 22 nat-to $att_if
 
 block all
 pass out quick inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -26,7 +26,7 @@ match out on $att_if from <turbo_hosts> to any nat-to $att_if
 # <turbo_sites> is a list of sites that should always be FAST
 match out on $att_if from any to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
-match out on $att_if inet from any to any port $turbo_ports nat-to $att_if
+match out on $att_if proto {udp,tcp} from any to any port $turbo_ports nat-to $att_if
 
 # Default to everything OK, except incoming traffic from the OUTSIDE
 pass all

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -2,7 +2,6 @@ zig_if  = "<%= @zig_if %>"
 att_if  = "<%= @att_if %>"
 int_if  = "<%= @int_if %>"
 mgm_if  = "<%= @mgm_if %>"
-int_net = "<%= @int_net %>.0/24"
 
 ext_ifs="{" $zig_if $att_if "}"
 int_ifs=$int_if
@@ -20,16 +19,16 @@ table <turbo_sites> counters
 match in all scrub (no-df random-id max-mss 1440)
 
 # Default all traffic to zig
-match out on $zig_if inet proto tcp modulate state from $int_net to any nat-to $zig_if
-match out on $zig_if inet proto udp     keep state from $int_net to any nat-to $zig_if
-match out on $zig_if inet                          from $int_net to any nat-to $zig_if
+match out on $zig_if inet proto tcp modulate state from $int_if:network to any nat-to $zig_if
+match out on $zig_if inet proto udp     keep state from $int_if:network to any nat-to $zig_if
+match out on $zig_if inet                          from $int_if:network to any nat-to $zig_if
 
 # <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
 match out on $att_if inet from <turbo_hosts> to any nat-to $att_if
 # <turbo_sites> is a list of sites that should always be FAST
-match out on $att_if inet from any to <turbo_sites> nat-to $att_if
+match out on $att_if inet from $int_if:network to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
-match out on $att_if inet proto tcp from any to any port 22 nat-to $att_if
+match out on $att_if inet proto tcp from $int_if:network to any port 22 nat-to $att_if
 
 block all
 pass out quick inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -25,9 +25,9 @@ match out on $zig_if from $int_net to any nat-to $zig_if
 # <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
 match out on $att_if from <turbo_hosts> to any nat-to $att_if
 # <turbo_sites> is a list of sites that should always be FAST
-match out on $att_if from $int_net to <turbo_sites> nat-to $att_if
+match out on $att_if from any to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
-match out on $att_if inet from $int_net to any port $turbo_ports nat-to $att_if
+match out on $att_if inet from any to any port $turbo_ports nat-to $att_if
 
 block all
 pass out inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -1,7 +1,7 @@
 zig_if  = <%= @zig_if %>
 att_if  = <%= @att_if %>
 int_if  = <%= @int_if %>
-int_net = <%= @int_if %>:network
+int_net = $int_if:network
 ext_ifs = "{" $zig_if $att_if "}"
 
 turbo_ports = "{ ssh, domain }"

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -30,7 +30,7 @@ match out on $zig_if from $int_net to any nat-to $zig_if
 
 # Default to everything OK, except incoming traffic from the OUTSIDE
 pass all
-block in on $ext_ifs
+block in log on $ext_ifs
 # Let me ssh from the external networks. This might be useful some day,
 # like if I need to connect to the AT&T access point or something.
 pass in on $ext_ifs proto tcp from any to any port ssh
@@ -53,3 +53,5 @@ pass in on $int_if proto {udp,tcp} from any to any port $turbo_ports route-to $a
 # Send zig-specific stuff to zig and at&t specific stuff to at&t.
 pass in on $int_if from any to $att_if:network route-to $att_route
 pass in on $int_if from any to $zig_if:network route-to $zig_route
+
+pass in from any to self

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -3,9 +3,7 @@ att_if  = <%= @att_if %>
 int_if  = <%= @int_if %>
 mgm_if  = <%= @mgm_if %>
 int_net = <%= @int_if %>:network
-
-ext_ifs="{" $zig_if $att_if "}"
-int_ifs=$int_if
+ext_ifs = "{" $zig_if $att_if "}"
 
 set block-policy drop
 set skip on lo0
@@ -20,18 +18,18 @@ table <turbo_sites> counters
 match in all scrub (no-df random-id max-mss 1440)
 
 # Default all traffic to zig
-match out on $zig_if inet proto tcp modulate state from $int_net to any nat-to $zig_if
-match out on $zig_if inet proto udp     keep state from $int_net to any nat-to $zig_if
-match out on $zig_if inet                          from $int_net to any nat-to $zig_if
+match out on $zig_if from $int_net to any nat-to $zig_if
 
 # <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
-match out on $att_if inet from <turbo_hosts> to any nat-to $att_if
+match out on $att_if from <turbo_hosts> to any nat-to $att_if
 # <turbo_sites> is a list of sites that should always be FAST
-match out on $att_if inet from $int_net to <turbo_sites> nat-to $att_if
+match out on $att_if from $int_net to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
 match out on $att_if inet proto tcp from $int_net to any port 22 nat-to $att_if
 
 block all
-pass out quick inet
+pass out inet
+pass out on $ext_ifs proto tcp modulate state
+pass out on $ext_ifs proto udp     keep state
 pass in on $int_if inet
 pass in on $mgm_if inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -14,8 +14,8 @@ set skip on lo0
 table <turbo_hosts> counters
 
 # This table will also be manipulated at runtime, but maybe not as much.
-# dominion
-table <turbo_sites> counters { <%= @turbo_sites.join(" ") %> }
+# stuff like dominion, screenhero, bluejeans?
+table <turbo_sites> counters
 
 match in all scrub (no-df random-id max-mss 1440)
 

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -1,7 +1,6 @@
 zig_if  = <%= @zig_if %>
 att_if  = <%= @att_if %>
 int_if  = <%= @int_if %>
-mgm_if  = <%= @mgm_if %>
 int_net = <%= @int_if %>:network
 ext_ifs = "{" $zig_if $att_if "}"
 
@@ -29,9 +28,12 @@ match out on $att_if from any to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
 match out on $att_if inet from any to any port $turbo_ports nat-to $att_if
 
-block all
+# Default to everything OK, except incoming traffic from the OUTSIDE
+pass all
+block in on $ext_ifs
+# Let me ssh from the external networks. This might be useful some day?
+pass in on $ext_ifs from any to any port ssh
+# Everything outgoing is OK.
 pass out inet
 pass out on $ext_ifs proto tcp modulate state
 pass out on $ext_ifs proto udp     keep state
-pass in on $int_if inet
-pass in on $mgm_if inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -1,7 +1,13 @@
 zig_if  = <%= @zig_if %>
+zig_gw  = <%= @zig_gw %>
 att_if  = <%= @att_if %>
+att_gw  = <%= @att_gw %>
 int_if  = <%= @int_if %>
 int_net = $int_if:network
+
+zig_route = "(" $zig_if $zig_gw ")"
+att_route = "(" $att_if $att_gw ")"
+
 ext_ifs = "{" $zig_if $att_if "}"
 
 turbo_ports = "{ ssh, domain }"
@@ -18,26 +24,32 @@ table <turbo_sites> counters
 
 match in all scrub (no-df random-id max-mss 1440)
 
-# Default all traffic to zig
+# NAT
+match out on $att_if from $int_net to any nat-to $att_if
 match out on $zig_if from $int_net to any nat-to $zig_if
-
-# <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
-match out on $att_if from <turbo_hosts> to any nat-to $att_if
-# <turbo_sites> is a list of sites that should always be FAST
-match out on $att_if from any to <turbo_sites> nat-to $att_if
-# Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
-match out on $att_if proto {udp,tcp} from any to any port $turbo_ports nat-to $att_if
-
-# Send zig-specific stuff to zig and at&t specific stuff to at&t.
-match out on $att_if to $att_if:network nat-to $att_if
-match out on $zig_if to $zig_if:network nat-to $zig_if
 
 # Default to everything OK, except incoming traffic from the OUTSIDE
 pass all
 block in on $ext_ifs
-# Let me ssh from the external networks. This might be useful some day?
+# Let me ssh from the external networks. This might be useful some day,
+# like if I need to connect to the AT&T access point or something.
 pass in on $ext_ifs proto tcp from any to any port ssh
+
 # Everything outgoing is OK.
 pass out inet
 pass out on $ext_ifs proto tcp modulate state
 pass out on $ext_ifs proto udp     keep state
+
+# Default all traffic to zig
+pass in on $int_if all route-to $zig_route
+
+# <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
+pass in on $int_if from <turbo_hosts> to any route-to $att_route
+# <turbo_sites> is a list of sites that should always be FAST
+pass in on $int_if from any to <turbo_sites> route-to $att_route
+# Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
+pass in on $int_if proto {udp,tcp} from any to any port $turbo_ports route-to $att_route
+
+# Send zig-specific stuff to zig and at&t specific stuff to at&t.
+pass in on $int_if from any to $att_if:network route-to $att_route
+pass in on $int_if from any to $zig_if:network route-to $zig_route

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -5,6 +5,8 @@ mgm_if  = <%= @mgm_if %>
 int_net = <%= @int_if %>:network
 ext_ifs = "{" $zig_if $att_if "}"
 
+turbo_ports = "{ ssh, domain }"
+
 set block-policy drop
 set skip on lo0
 
@@ -25,7 +27,7 @@ match out on $att_if from <turbo_hosts> to any nat-to $att_if
 # <turbo_sites> is a list of sites that should always be FAST
 match out on $att_if from $int_net to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
-match out on $att_if inet proto tcp from $int_net to any port 22 nat-to $att_if
+match out on $att_if inet from $int_net to any port $turbo_ports nat-to $att_if
 
 block all
 pass out inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -1,6 +1,7 @@
 zig_if=<%= @zig_if %>
 att_if=<%= @att_if %>
 int_if=<%= @int_if %>
+mgm_if=<%= @mgm_if %>
 
 ext_ifs="{" $zig_if $att_if "}"
 int_ifs=$int_if
@@ -32,3 +33,4 @@ match out on $att_if inet proto tcp from any to any port 22 nat-to $att_if
 block all
 pass out quick inet
 pass in on $int_if inet
+pass in on $mgm_if inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -1,8 +1,8 @@
-zig_if=<%= @zig_if %>
-att_if=<%= @att_if %>
-int_if=<%= @int_if %>
-mgm_if=<%= @mgm_if %>
-int_net=<%= @int_net %>.0/24
+zig_if  = "<%= @zig_if %>"
+att_if  = "<%= @att_if %>"
+int_if  = "<%= @int_if %>"
+mgm_if  = "<%= @mgm_if %>"
+int_net = "<%= @int_net %>.0/24"
 
 ext_ifs="{" $zig_if $att_if "}"
 int_ifs=$int_if

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -12,21 +12,12 @@ local_ip=<%= @int_ip %>
 ext_ifs="{" $zig_if $att_if "}"
 int_ifs=$int_if
 
-table <martians> { 0.0.0.0/8 10.0.0.0/8 127.0.0.0/8 169.254.0.0/16     \
-                   172.16.0.0/12 192.0.0.0/24 192.0.2.0/24 224.0.0.0/3 \
-                   192.168.0.0/16 198.18.0.0/15 198.51.100.0/24        \
-                   203.0.113.0/24 }
-
 set block-policy drop
 set skip on lo0
 
 match in all scrub (no-df random-id max-mss 1440)
 match out on $att_if inet from $int_net to any nat-to $att_if
 match out on $zig_if inet from $int_net to any nat-to $zig_if
-
-# todo - make this more lax re att_net and zig_net
-block in quick on $ext_ifs from <martians> to any
-block return out quick on $ext_ifs from any to <martians>
 
 block all
 pass out quick inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -8,3 +8,26 @@ att_ip=<%= @att_ip %>
 local_zig_ip=<%= @local_zig_ip %>
 local_att_ip=<%= @local_att_ip %>
 local_ip=<%= @int_ip %>
+
+ext_ifs="{" $zig_if $att_if "}"
+int_ifs=$int_if
+
+table <martians> { 0.0.0.0/8 10.0.0.0/8 127.0.0.0/8 169.254.0.0/16     \
+                   172.16.0.0/12 192.0.0.0/24 192.0.2.0/24 224.0.0.0/3 \
+                   192.168.0.0/16 198.18.0.0/15 198.51.100.0/24        \
+                   203.0.113.0/24 }
+
+set block-policy drop
+set skip on lo0
+
+match in all scrub (no-df random-id max-mss 1440)
+match out on $att_if inet from $int_net to any nat-to $att_if
+match out on $zig_if inet from $int_net to any nat-to $zig_if
+
+# todo - make this more lax re att_net and zig_net
+block in quick on $ext_ifs from <martians> to any
+block return out quick on $ext_ifs from any to <martians>
+
+block all
+pass out quick inet
+pass in on $int_if inet

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -28,6 +28,10 @@ match out on $att_if from any to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
 match out on $att_if proto {udp,tcp} from any to any port $turbo_ports nat-to $att_if
 
+# Send zig-specific stuff to zig and at&t specific stuff to at&t.
+match out on $att_if to $att_if:network nat-to $att_if
+match out on $zig_if to $zig_if:network nat-to $zig_if
+
 # Default to everything OK, except incoming traffic from the OUTSIDE
 pass all
 block in on $ext_ifs

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -11,6 +11,10 @@ set skip on lo0
 # This table will be manipulated at runtime
 table <turbo_hosts> counters
 
+# This table will also be manipulated at runtime, but maybe not as much.
+# dominion
+table <turbo_sites> counters { <%= @turbo_sites.join(" ") %> }
+
 match in all scrub (no-df random-id max-mss 1440)
 
 # Default all traffic to zig
@@ -20,6 +24,8 @@ match out on $zig_if inet                          from $int_net to any nat-to $
 
 # <turbo_hosts> is an opt-in list of hosts that want a burst of SPEED
 match out on $att_if inet from <turbo_hosts> to any nat-to $att_if
+# <turbo_sites> is a list of sites that should always be FAST
+match out on $att_if inet from any to <turbo_sites> nat-to $att_if
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
 match out on $att_if inet proto tcp from any to any port 22 nat-to $att_if
 

--- a/modules/spraints/templates/var/unbound/etc/unbound.conf.erb
+++ b/modules/spraints/templates/var/unbound/etc/unbound.conf.erb
@@ -1,0 +1,12 @@
+# Based on http://www.openbsd.org/faq/pf/example1.html
+server:
+  interface: <%= @int_ip %>
+  interface: 127.0.0.1
+  access-control: <%= @int_net %>.0/24 allow
+  do-not-query-localhost: no
+  hide-identity: yes
+  hide-version: yes
+
+forward-zone:
+  name: "."
+  forward-addr: 8.8.8.8@53

--- a/nohup-run
+++ b/nohup-run
@@ -1,0 +1,2 @@
+#/ Usage: . nohup-run
+nohup sh -x run "$@" & tail -f nohup.out

--- a/run
+++ b/run
@@ -69,7 +69,7 @@ case `uname -s` in
     ;;
 
   OpenBSD)
-    doas pkg_add ruby-facter ruby-puppet git curl ruby-bundler
+    doas pkg_add facter puppet git curl ruby22-bundler
     ;;
 
   *)

--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #/ Usage: curl -L https://github.com/spraints/homenetwork/raw/master/run | bash
 
 set -e
@@ -12,12 +12,12 @@ step() {
 }
 
 banner() {
-  echo ========================================================================
-  echo = "$@"
-  echo ========================================================================
+  echo "========================================================================"
+  echo "= $*"
+  echo "========================================================================"
 }
 
-# Ensure that puppet, curl, git, bundler, and sudo are installed.
+# Ensure that puppet (e.g. 3.7.3), curl, git, bundler, and sudo are installed.
 case `uname -s` in
   Linux)
     if ! dpkg -s puppet-common >/dev/null 2>/dev/null; then

--- a/run
+++ b/run
@@ -69,11 +69,22 @@ case `uname -s` in
     ;;
 
   OpenBSD)
+    pkg_info -q -e 'git->=0.0'            || packages="$packages git"
+    pkg_info -q -e 'curl->=0.0'           || packages="$packages curl"
+    pkg_info -q -e 'ruby22-bundler->=0.0' || packages="$packages ruby22-bundler"
+    pkg_info -q -e 'puppet->=0.0'         || packages="$packages puppet"
+
     case `uname -r` in
       5.8)
-        facter_version=-2.4.4p2 ;;
+        pkg_info -q -e facter-2.4.4p2 || packages="$packages facter-2.4.4p2"
+        ;;
+
+      *)
+        pkg_info -q -e 'facter->0.0'  || packages="$packages facter"
+        ;;
     esac
-    $sudo pkg_add facter${facter_version} puppet git curl ruby22-bundler
+
+    test -n "$packages" && $sudo pkg_add $packages
 
     for exe in bundle erb gem hiera irb rake rdoc ri ruby; do
       if [ ! -f /usr/local/bin/$exe ]; then

--- a/run
+++ b/run
@@ -3,7 +3,9 @@
 
 set -e
 
-sudo -p "We need sudo privileges to run puppet. Please type your password: " /bin/true
+if which sudo >/dev/null 2>/dev/null; then
+  sudo -p "We need sudo privileges to run puppet. Please type your password: " /bin/true
+fi
 
 step() {
   echo '====>' "$@"
@@ -15,33 +17,44 @@ banner() {
   echo ========================================================================
 }
 
-if ! dpkg -s puppet-common >/dev/null 2>/dev/null; then
-  step Install puppet per https://docs.puppetlabs.com/guides/install_puppet/install_debian_ubuntu.html
-  (
-    set -e
-    cd /tmp
-    deb=puppetlabs-release-trusty.deb
-    curl -O https://apt.puppetlabs.com/${deb}
-    sudo dpkg -i ${deb}
-    rm ${deb}
-  )
-  packages_to_install="${packages_to_install} puppet"
-fi
+# Ensure that puppet, curl, git, bundler, and sudo are installed.
+case `uname -s` in
+  Linux)
+    if ! dpkg -s puppet-common >/dev/null 2>/dev/null; then
+      step Install puppet per https://docs.puppetlabs.com/guides/install_puppet/install_debian_ubuntu.html
+      (
+        set -e
+        cd /tmp
+        deb=puppetlabs-release-trusty.deb
+        curl -O https://apt.puppetlabs.com/${deb}
+        sudo dpkg -i ${deb}
+        rm ${deb}
+      )
+      packages_to_install="${packages_to_install} puppet"
+    fi
 
-if ! dpkg -s git >/dev/null 2>/dev/null; then
-  step Install git
-  packages_to_install="${packages_to_install} git"
-fi
+    if ! dpkg -s git >/dev/null 2>/dev/null; then
+      step Install git
+      packages_to_install="${packages_to_install} git"
+    fi
 
-if ! dpkg -s bundler >/dev/null 2>/dev/null; then
-  step Install bundler
-  packages_to_install="${packages_to_install} bundler"
-fi
+    if ! dpkg -s bundler >/dev/null 2>/dev/null; then
+      step Install bundler
+      packages_to_install="${packages_to_install} bundler"
+    fi
 
-if [ -n "${packages_to_install}" ]; then
-  sudo apt-get update
-  sudo apt-get install -y ${packages_to_install}
-fi
+    if [ -n "${packages_to_install}" ]; then
+      sudo apt-get update
+      sudo apt-get install -y ${packages_to_install}
+    fi
+
+    ;;
+
+  *)
+    echo `uname -s` is not supported.
+    exit 1
+    ;;
+esac
 
 repo_path=/var/local/homenetwork-puppet
 if ! test -d ${repo_path}; then

--- a/run
+++ b/run
@@ -77,7 +77,7 @@ case `uname -s` in
 
     for exe in bundle erb gem hiera irb rake rdoc ri ruby; do
       if [ ! -f /usr/local/bin/$exe ]; then
-        ln -s "$exe"22 /usr/local/bin/$exe
+        doas ln -s "$exe"22 /usr/local/bin/$exe
       fi
     done
     ;;

--- a/run
+++ b/run
@@ -69,7 +69,11 @@ case `uname -s` in
     ;;
 
   OpenBSD)
-    doas pkg_add facter puppet git curl ruby22-bundler
+    case `uname -r` in
+      5.8)
+        facter_version=-2.4.4p2 ;;
+    esac
+    doas pkg_add facter${facter_version} puppet git curl ruby22-bundler
     ;;
 
   *)

--- a/run
+++ b/run
@@ -13,11 +13,15 @@ if which sudo >/dev/null 2>/dev/null; then
   sudo=sudo
 else
   if which doas >/dev/null 2>/dev/null; then
-    if ! sudodoas true; then
-      echo You gotta enable doas first.
-      exit 1
+    if doas -n true; then
+      sudo=doas
+    else
+      if ! sudodoas true; then
+        echo You gotta enable doas first.
+        exit 1
+      fi
+      sudo=sudodoas
     fi
-    sudo=sudodoas
   fi
 fi
 
@@ -65,8 +69,7 @@ case `uname -s` in
     ;;
 
   OpenBSD)
-    echo TODO
-    exit 1
+    doas pkg_add ruby-facter ruby-puppet git curl ruby-bundler
     ;;
 
   *)

--- a/run
+++ b/run
@@ -3,8 +3,22 @@
 
 set -e
 
+sudodoas() {
+  echo Running "$@"
+  doas "$@"
+}
+
 if which sudo >/dev/null 2>/dev/null; then
-  sudo -p "We need sudo privileges to run puppet. Please type your password: " /bin/true
+  sudo -p "We need sudo privileges to run puppet. Please type your password: " true
+  sudo=sudo
+else
+  if which doas >/dev/null 2>/dev/null; then
+    if ! sudodoas true; then
+      echo You gotta enable doas first.
+      exit 1
+    fi
+    sudo=sudodoas
+  fi
 fi
 
 step() {
@@ -50,6 +64,11 @@ case `uname -s` in
 
     ;;
 
+  OpenBSD)
+    echo TODO
+    exit 1
+    ;;
+
   *)
     echo `uname -s` is not supported.
     exit 1
@@ -59,8 +78,8 @@ esac
 repo_path=/var/local/homenetwork-puppet
 if ! test -d ${repo_path}; then
   step Initialize repository
-  sudo mkdir -p ${repo_path}
-  sudo chown `id -u` ${repo_path}
+  $sudo mkdir -p ${repo_path}
+  $sudo chown `id -u` ${repo_path}
   git init ${repo_path}
 fi
 
@@ -110,4 +129,4 @@ fi
 
 step Apply
 set -x
-sudo puppet apply --show_diff "$@" --modulepath ${repo_path}/modules ${hiera_opts} ${repo_path}/manifests/
+$sudo puppet apply --show_diff "$@" --modulepath ${repo_path}/modules ${hiera_opts} ${repo_path}/manifests/

--- a/run
+++ b/run
@@ -137,7 +137,7 @@ if ! git rev-parse "${ref}" >/dev/null 2>/dev/null; then
 fi
 git reset --hard "${ref}"
 git clean -d -n
-git show -q HEAD
+git --no-pager show -q HEAD
 
 script/bootstrap
 

--- a/run
+++ b/run
@@ -73,11 +73,11 @@ case `uname -s` in
       5.8)
         facter_version=-2.4.4p2 ;;
     esac
-    doas pkg_add facter${facter_version} puppet git curl ruby22-bundler
+    $sudo pkg_add facter${facter_version} puppet git curl ruby22-bundler
 
     for exe in bundle erb gem hiera irb rake rdoc ri ruby; do
       if [ ! -f /usr/local/bin/$exe ]; then
-        doas ln -s "$exe"22 /usr/local/bin/$exe
+        $sudo ln -s "$exe"22 /usr/local/bin/$exe
       fi
     done
     ;;

--- a/run
+++ b/run
@@ -153,4 +153,4 @@ fi
 
 step Apply
 set -x
-$sudo puppet apply --show_diff "$@" --modulepath ${repo_path}/modules ${hiera_opts} ${repo_path}/manifests/
+$sudo puppet apply --show_diff --verbose "$@" --modulepath ${repo_path}/modules ${hiera_opts} ${repo_path}/manifests/

--- a/run
+++ b/run
@@ -74,6 +74,12 @@ case `uname -s` in
         facter_version=-2.4.4p2 ;;
     esac
     doas pkg_add facter${facter_version} puppet git curl ruby22-bundler
+
+    for exe in bundle erb gem hiera irb rake rdoc ri ruby; do
+      if [ ! -f /usr/local/bin/$exe ]; then
+        ln -s "$exe"22 /usr/local/bin/$exe
+      fi
+    done
     ;;
 
   *)


### PR DESCRIPTION
I have two routes out to the internet. One is cheap and flaky (zig). One is expensive and awesome (att). Eventually, I'm going to get a PC with 3 NICs and OpenBSD that can route traffic somewhat intelligently across the two. For now, this config sends everything via zig, except ssh. There's a table of hosts that get special treatment. Eventually, I'll write a self-service thing so that I can click "boost me" and get all my traffic sent over the att link.

* [x] pf.conf
* [x] dhcpd
* [x] dhcpd reservations (gist, copied from airport)
* [x] caching dns server (very excited to try this)
* [x] Make `run` work on OpenBSD
* [ ] Change `script/update-hieradata` to use git to fetch it
* [ ] "boost me" app