### PR TITLE
Download some things at whatever speed

### DIFF
--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -107,7 +107,7 @@ class spraints::role::router(
     provider => git,
     user     => "root",
     source   => "https://github.com/spraints/sprouter",
-    revision => "5ddb74d2c8f3f42a427964db55efecfba31a694a",
+    revision => "6401e80b1063b8a27d4cbeb027af7ca8c514df1b",
     require  => File[$sprouter_root],
   }
 

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -22,6 +22,10 @@ table <turbo_hosts> counters
 # stuff like dominion, screenhero, bluejeans?
 table <turbo_sites> counters
 
+# This table will also be manipulated at runtime, but maybe not as much.
+# stuff like app store downloads.
+table <slow_sites> counters
+
 match in all scrub (no-df random-id max-mss 1440)
 
 # NAT
@@ -47,6 +51,8 @@ pass in on $int_if all route-to $zig_route
 pass in on $int_if from <turbo_hosts> to any route-to $att_route
 # <turbo_sites> is a list of sites that should always be FAST
 pass in on $int_if from any to <turbo_sites> route-to $att_route
+# <slow_sites> is a list of sites that should never be fast
+pass in on $int_if from any to <slow_sites> route-to $zig_route
 # Send all ssh sessions over AT&T. They should be low bandwidth, and it'd be nice if they're fast.
 pass in on $int_if proto {udp,tcp} from any to any port $turbo_ports route-to $att_route
 

--- a/modules/spraints/templates/etc/pf.conf.erb
+++ b/modules/spraints/templates/etc/pf.conf.erb
@@ -36,9 +36,9 @@ block in log on $ext_ifs
 pass in on $ext_ifs proto tcp from any to any port ssh
 
 # Everything outgoing is OK.
-pass out inet
-pass out on $ext_ifs proto tcp modulate state
-pass out on $ext_ifs proto udp     keep state
+pass out log inet
+pass out log on $ext_ifs proto tcp modulate state
+pass out log on $ext_ifs proto udp     keep state
 
 # Default all traffic to zig
 pass in on $int_if all route-to $zig_route

--- a/modules/spraints/templates/var/local/visage/profiles.yaml.d/zig-or-att.yaml.erb
+++ b/modules/spraints/templates/var/local/visage/profiles.yaml.d/zig-or-att.yaml.erb
@@ -4,6 +4,7 @@ pftablesizes:
   :metrics:
   - pftable-turbo_hosts/gauge-addresses
   - pftable-turbo_sites/gauge-addresses
+  - pftable-slow_sites/gauge-addresses
   :percentiles:
   :profile_name: pftablesizes
   :url: pftablesizes
@@ -14,6 +15,7 @@ pftabletraffic:
   :metrics:
   - pftable-turbo_hosts/if_octets-pass
   - pftable-turbo_sites/if_octets-pass
+  - pftable-slow_sites/if_octets-pass
   :percentiles:
   :profile_name: pftabletraffic
   :url: pftabletraffic


### PR DESCRIPTION
Some things don't need to download fast, even if the connection is bad. For example, when downloading el capitan, I'd rather retry the download a bunch of times than use 4GB on the metered connection.

uses https://github.com/spraints/sprouter/pull/3