### PR TITLE
Make it easier to switch dhcp vs static ip in hieradata

### DIFF
--- a/modules/spraints/manifests/device/interface.pp
+++ b/modules/spraints/manifests/device/interface.pp
@@ -1,12 +1,11 @@
 define spraints::device::interface(
   $interface = $name,
-  $dhcp      = false,
   $address   = undef,
   $netmask   = undef,
   $bcast     = undef,
 ) {
   if $::operatingsystem == "OpenBSD" {
-    if $dhcp == false and $address == undef {
+    if $address == undef {
 
       file { "/etc/hostname.${interface}":
         ensure  => absent,

--- a/modules/spraints/manifests/role/router.pp
+++ b/modules/spraints/manifests/role/router.pp
@@ -4,8 +4,10 @@
 class spraints::role::router(
   $zig_if = "re0",
   $zig_gw = "192.168.3.1",
+  $zig_ip = "dhcp",
   $att_if = "re1",
   $att_gw = "192.168.0.1",
+  $att_ip = "dhcp",
   $int_if = "re2",
   $int_ip = "192.168.100.2",
   $int_net = "192.168.100",
@@ -29,13 +31,26 @@ class spraints::role::router(
   # But DHCP on these bites because I can't choose a default route with /etc/mygate
   # and pf will barf if the NIC isn't connected, because the interface won't have an IP
   # address.
-  spraints::device::interface { [$zig_if, $att_if, $mgm_if]:
-    dhcp    => true,
-    notify  => Exec["reload pf.conf"],
+  spraints::device::interface {
+    $int_if:
+      address => $int_ip,
+      notify  => Exec["reload pf.conf"];
+    $zig_if:
+      address => $zig_ip,
+      notify  => Exec["reload pf.conf"];
+    $att_if:
+      address => $att_ip,
+      notify  => Exec["reload pf.conf"];
+    $mgm_if:
+      address => "dhcp",
+      notify  => Exec["reload pf.conf"];
   }
-  spraints::device::interface { $int_if:
-    address => $int_ip,
-    notify  => Exec["reload pf.conf"],
+
+  file { "/etc/mygate":
+    ensure  => present,
+    owner   => "root",
+    mode    => "444",
+    content => "${att_gw}\n",
   }
 
   ###

--- a/modules/spraints/templates/etc/hostname.if.erb
+++ b/modules/spraints/templates/etc/hostname.if.erb
@@ -1,3 +1,3 @@
 <% if @address == "dhcp" %>dhcp
-<% else %>inet <%= @address %> <%= @netmask || "255.255.255.0" %> <%= @bcast || @address.to_s.sub(/\.[d+]$/, ".255") %>
+<% else %>inet <%= @address %> <%= @netmask || "255.255.255.0" %> <%= @bcast || @address.to_s.sub(/\.\d+$/, ".255") %>
 <% end %>

--- a/modules/spraints/templates/etc/hostname.if.erb
+++ b/modules/spraints/templates/etc/hostname.if.erb
@@ -1,3 +1,3 @@
-<% if @dhcp %>dhcp
+<% if @address == "dhcp" %>dhcp
 <% else %>inet <%= @address %> <%= @netmask || "255.255.255.0" %> <%= @bcast || @address.to_s.sub(/\.[d+]$/, ".255") %>
 <% end %>


### PR DESCRIPTION
The last time the router booted, it came up with the slow link as the default gateway. This causes problems with DNS and maybe some other stuff. I manually switched it by running `doas route -qn delete default; doas route -qn add -host default $fast_gate`. This branch will let me configure it via hieradata.