### PR TITLE
make it easier to swap out the router

### DIFF
--- a/modules/spraints/templates/etc/dhcpd.conf.erb
+++ b/modules/spraints/templates/etc/dhcpd.conf.erb
@@ -1,5 +1,8 @@
 option domain-name-servers <%= @dhcp_name_servers.join(", ") %>;
 subnet <%= @int_net %>.0 netmask 255.255.255.0 {
+  # 1h lease, so that it's easier to switch up the router
+  max-lease-time 60;
+
   option routers <%= @int_ip %>;
   range <%= @int_net %>.100 <%= @int_net %>.199;
   <% @dhcp_reservations.each do |name, attrs| %>


### PR DESCRIPTION
I'm probably going to install pfsense on the router in place of openbsd. when i do, i may also change some config, like maybe the IP address if I'm not careful. So, this makes dhcpd give out shorter leases so that i don't have to go around reseting the network connection on all my devices every time.